### PR TITLE
状況・問題・目標に文字数制限を追加し、「次へ」を押した時点でエラーが表示されるようにする

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,7 +5,7 @@ class SessionsController < ApplicationController
     auth = request.env["omniauth.auth"]
     user = User.find_or_create_from_auth_hash(auth)
     session[:user_id] = user.id
-     redirect_to "/home"
+     redirect_to new_situation_path
   end
 
   def destroy

--- a/app/javascript/controllers/situation_form_controller.js
+++ b/app/javascript/controllers/situation_form_controller.js
@@ -1,13 +1,15 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["step"];
+  static targets = ["step", "input", "error"];
+
   connect() {
     this.currentStep = 0;
     this.showCurrentStep();
   }
 
   next() {
+    if (!this.validateCurrentStep()) return;
     this.currentStep++;
     this.showCurrentStep();
   }
@@ -17,9 +19,43 @@ export default class extends Controller {
     this.showCurrentStep();
   }
 
+  submit(event) {
+    if (!this.validateCurrentStep()) {
+      event.preventDefault();
+    }
+  }
+
   showCurrentStep() {
     this.stepTargets.forEach((step, index) => {
       step.classList.toggle("hidden", index !== this.currentStep);
     });
+  }
+
+  clearError() {
+    const error = this.errorTargets[this.currentStep];
+    error.textContent = "";
+    error.classList.add("hidden");
+  }
+
+  validateCurrentStep() {
+    const input = this.inputTargets[this.currentStep];
+    const error = this.errorTargets[this.currentStep];
+
+    if (input.value.trim() === "") {
+      error.textContent = "入力してください。";
+      error.classList.remove("hidden");
+      input.focus();
+      return false;
+    }
+
+    if (input.value.length > 300) {
+      error.textContent = "300文字以内にしてください。";
+      error.classList.remove("hidden");
+      input.focus();
+      return false;
+    }
+
+    this.clearError();
+    return true;
   }
 }

--- a/app/javascript/controllers/situation_form_controller.js
+++ b/app/javascript/controllers/situation_form_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["step", "input", "error"];
+  static targets = ["step", "input", "error", "output"];
 
   connect() {
     this.currentStep = 0;
@@ -29,6 +29,19 @@ export default class extends Controller {
     this.stepTargets.forEach((step, index) => {
       step.classList.toggle("hidden", index !== this.currentStep);
     });
+  }
+
+  count(event) {
+    this.updateCount(event.currentTarget);
+  }
+
+  updateCount(input) {
+    const index = this.inputTargets.indexOf(input);
+    const output = this.outputTargets[index];
+    const length = input.value.length;
+    output.textContent = length;
+    output.classList.toggle("text-red-600", length > 300);
+    output.classList.toggle("font-bold", length > 300);
   }
 
   clearError() {

--- a/app/models/situation.rb
+++ b/app/models/situation.rb
@@ -1,9 +1,9 @@
 class Situation < ApplicationRecord
   belongs_to :user
 
-  validates :fact, presence: true
-  validates :problem, presence: true
-  validates :goal, presence: true
+  validates :fact, presence: true, length: { maximum: 300 }
+  validates :problem, presence: true, length: { maximum: 300 }
+  validates :goal, presence: true, length: { maximum: 200 }
 
   enum :status, {
     pending: 0,

--- a/app/models/situation.rb
+++ b/app/models/situation.rb
@@ -3,7 +3,7 @@ class Situation < ApplicationRecord
 
   validates :fact, presence: true, length: { maximum: 300 }
   validates :problem, presence: true, length: { maximum: 300 }
-  validates :goal, presence: true, length: { maximum: 200 }
+  validates :goal, presence: true, length: { maximum: 300 }
 
   enum :status, {
     pending: 0,

--- a/app/views/situations/new.html.erb
+++ b/app/views/situations/new.html.erb
@@ -2,26 +2,33 @@
   <h1 class="font-bold text-4xl">Situations#new</h1>
   <p>Find me in app/views/situations/new.html.erb</p>
 
-  <%= render "application/errors", object: @situation %>
-
   <div>
-    <%= form_with model: @situation do |f| %>
+    <%= form_with model: @situation, data: { action: "submit->situation-form#submit" } do |f| %>
       <div data-situation-form-target="step" class="block">
         <%= f.label :fact, class:"block text-gray-500 font-bold md:text-left mt-3 text-xl" %>
-        <%= f.text_area :fact, class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full h-50 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-orange-400" %>
+        <%= f.text_area :fact, class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full h-50 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-orange-400", data: { situation_form_target: "input", action: "input->situation-form#clearError" } %>
+
+        <p class="hidden text-red-600 font-bold" data-situation-form-target="error"></p>
+
         <button type="button" data-action="click->situation-form#next" class="bg-sky-700 hover:bg-sky-900 text-white font-bold mt-3 py-2 px-4 rounded">次へ</button>
       </div>
 
       <div data-situation-form-target="step" class="block">
         <%= f.label :problem, class:"block text-gray-500 font-bold md:text-left mt-3 text-xl" %>
-        <%= f.text_area :problem, class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full h-50 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-orange-400" %>
+        <%= f.text_area :problem, class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full h-50 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-orange-400", data: { situation_form_target: "input", action: "input->situation-form#clearError" } %>
+
+        <p class="hidden text-red-600 font-bold" data-situation-form-target="error"></p>
+
         <button type="button" data-action="click->situation-form#prev" class="bg-sky-700 hover:bg-sky-900 text-white font-bold mt-3 py-2 px-4 rounded">戻る</button>
         <button type="button" data-action="click->situation-form#next" class="bg-sky-700 hover:bg-sky-900 text-white font-bold mt-3 py-2 px-4 rounded">次へ</button>
       </div>
 
       <div data-situation-form-target="step" class="block">
         <%= f.label :goal, class:"block text-gray-500 font-bold md:text-left mt-3 text-xl" %>
-        <%= f.text_area :goal, class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full h-50 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-orange-400" %>
+        <%= f.text_area :goal, class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full h-50 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-orange-400", data: { situation_form_target: "input", action: "input->situation-form#clearError" } %>
+
+        <p class="hidden text-red-600 font-bold" data-situation-form-target="error"></p>
+
         <button type="button" data-action="click->situation-form#prev" class="bg-sky-700 hover:bg-sky-900 text-white font-bold mt-3 py-2 px-4 rounded">戻る</button>
         <%= f.submit "送信", class:"bg-sky-700 hover:bg-sky-900 text-white font-bold mt-3 py-2 px-4 rounded" %>
       </div>

--- a/app/views/situations/new.html.erb
+++ b/app/views/situations/new.html.erb
@@ -6,7 +6,11 @@
     <%= form_with model: @situation, data: { action: "submit->situation-form#submit" } do |f| %>
       <div data-situation-form-target="step" class="block">
         <%= f.label :fact, class:"block text-gray-500 font-bold md:text-left mt-3 text-xl" %>
-        <%= f.text_area :fact, class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full h-50 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-orange-400", data: { situation_form_target: "input", action: "input->situation-form#clearError" } %>
+        <%= f.text_area :fact, class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full h-50 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-orange-400", data: { situation_form_target: "input", action: "input->situation-form#clearError input->situation-form#count" } %>
+
+        <p>
+          文字数： <span data-situation-form-target="output">0</span> / 300文字
+        </p>
 
         <p class="hidden text-red-600 font-bold" data-situation-form-target="error"></p>
 
@@ -15,7 +19,11 @@
 
       <div data-situation-form-target="step" class="block">
         <%= f.label :problem, class:"block text-gray-500 font-bold md:text-left mt-3 text-xl" %>
-        <%= f.text_area :problem, class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full h-50 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-orange-400", data: { situation_form_target: "input", action: "input->situation-form#clearError" } %>
+        <%= f.text_area :problem, class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full h-50 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-orange-400", data: { situation_form_target: "input", action: "input->situation-form#clearError input->situation-form#count" } %>
+
+        <p>
+          文字数： <span data-situation-form-target="output">0</span> / 300文字
+        </p>
 
         <p class="hidden text-red-600 font-bold" data-situation-form-target="error"></p>
 
@@ -25,7 +33,11 @@
 
       <div data-situation-form-target="step" class="block">
         <%= f.label :goal, class:"block text-gray-500 font-bold md:text-left mt-3 text-xl" %>
-        <%= f.text_area :goal, class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full h-50 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-orange-400", data: { situation_form_target: "input", action: "input->situation-form#clearError" } %>
+        <%= f.text_area :goal, class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full h-50 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-orange-400", data: { situation_form_target: "input", action: "input->situation-form#clearError input->situation-form#count" } %>
+
+        <p>
+          文字数： <span data-situation-form-target="output">0</span> / 300文字
+        </p>
 
         <p class="hidden text-red-600 font-bold" data-situation-form-target="error"></p>
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,10 +5,6 @@ ja:
         fact: 現在の状況
         problem: 悩み
         goal: 目標
-    errors:
-      models:
-        situation:
-          too_long: は300文字以内にしてください。
   errors:
     messages:
       blank: を入力してください

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,6 +5,10 @@ ja:
         fact: 現在の状況
         problem: 悩み
         goal: 目標
+    errors:
+      models:
+        situation:
+          too_long: は300文字以内にしてください。
   errors:
     messages:
       blank: を入力してください

--- a/spec/models/situation_spec.rb
+++ b/spec/models/situation_spec.rb
@@ -11,5 +11,25 @@ RSpec.describe Situation, type: :model do
       situation = build(:situation, fact: nil, problem: nil, goal: nil)
       expect(situation).not_to be_valid
     end
+
+    it "状況、問題、目標が300文字以内なら登録できる" do
+      situation = build(
+        :situation,
+        fact: "あ" * 300,
+        problem: "あ" * 300,
+        goal: "あ" * 300
+      )
+      expect(situation).to be_valid
+    end
+
+    it "状況、問題、目標が301文字以上だと登録できない" do
+      situation = build(
+        :situation,
+        fact: "あ" * 301,
+        problem: "あ" * 301,
+        goal: "あ" * 301
+      )
+      expect(situation).not_to be_valid
+    end
   end
 end


### PR DESCRIPTION
## Issue

- #86 
- #81

## 概要

- 送信まで押さないとエラーが表示されない
- エラーが出たままになっている

上記二点を修正し、エラーもフロントで処理させるようにしました。
また、併せて以下も対応しました。

- [x] 今入力している文字数を表示する
- [x] Googleでログイン後、入力画面に遷移するよう変更
- [x] 文字数制限のテストを追加する

## 日報

- [403日目：自作サービス10\(デモアプリでAIを検証する\) \| FBC](https://bootcamp.fjord.jp/reports/125018)
- [404日目：自作サービス11 \| FBC](https://bootcamp.fjord.jp/reports/125046)

## スクリーンショット

### 変更前

https://github.com/user-attachments/assets/f6e6cd37-8023-46d6-89fc-96217b067dd5

### 変更後

<img width="783" height="438" alt="image" src="https://github.com/user-attachments/assets/41e44b06-636a-4073-92d9-1626cfcc742b" />
<img width="759" height="437" alt="image" src="https://github.com/user-attachments/assets/763c60cf-83f9-4051-a38a-0f02bc803381" />


