### PR TITLE
質問回答入力画面・詳細画面を共通化

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "editor.formatOnSave": true,
+  "[erb]": {
+    "editor.defaultFormatter": "aliariff.vscode-erb-beautify"
+  },
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :development, :test do
 
   gem "rspec-rails"
   gem "factory_bot_rails"
+  gem "htmlbeautifier"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,7 @@ GEM
       activesupport (>= 6.1)
     hashie (5.1.0)
       logger
+    htmlbeautifier (1.4.3)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.2.3)
@@ -451,6 +452,7 @@ DEPENDENCIES
   capybara
   debug
   factory_bot_rails
+  htmlbeautifier
   importmap-rails
   kamal
   omniauth
@@ -517,6 +519,7 @@ CHECKSUMS
   fugit (1.12.2) sha256=643f2bf28db263bd400cbf8e0dd8b76b2c9b94bdb130e12d2394de04d9c20e5e
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   hashie (5.1.0) sha256=c266471896f323c446ea8207f8ffac985d2718df0a0ba98651a3057096ca3870
+  htmlbeautifier (1.4.3) sha256=b43d08f7e2aa6ae1b5a6f0607b4ed8954c8d4a8e85fd2336f975dda1e4db385b
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -2,4 +2,9 @@
 
 <p class="mt-4 mb-4">Googleアカウントでログインしてください</p>
 
-<%= button_to "Googleでログイン", "/auth/google_oauth2", method: :post, class: "bg-blue-500 hover:bg-blue-400 text-white font-bold py-2 px-4 border-b-4 border-blue-700 hover:border-blue-500 rounded", form: { data: { turbo: false } } %>
+<%= button_to "Googleでログイン",
+  "/auth/google_oauth2",
+  method: :post,
+  class: "rounded border-b-4 border-blue-700 bg-blue-500 px-4 py-2 font-bold text-white hover:border-blue-500 hover:bg-blue-400",
+  form: { data: { turbo: false } } 
+%>

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -6,4 +6,8 @@
   さん
 </p>
 
-<%= button_to "ログアウト", logout_path, method: :delete, class: "bg-blue-500 hover:bg-blue-400 text-white font-bold py-2 px-4 border-b-4 border-blue-700 hover:border-blue-500 rounded" %>
+<%= button_to "ログアウト",
+  logout_path,
+  method: :delete,
+  class: "rounded border-b-4 border-blue-700 bg-blue-500 px-4 py-2 font-bold text-white hover:border-blue-500 hover:bg-blue-400" 
+%>

--- a/app/views/situations/_form_text_area.html.erb
+++ b/app/views/situations/_form_text_area.html.erb
@@ -1,0 +1,15 @@
+<%= f.label attribute, 
+  class:"block text-gray-500 font-bold md:text-left mt-3 text-xl" 
+%>
+
+<%= f.text_area attribute, 
+  class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full h-50 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-orange-400", 
+  data: { situation_form_target: "input", 
+  action: "input->situation-form#clearError input->situation-form#count" }
+%>
+
+<p>
+  文字数： <span data-situation-form-target="output">0</span> / 300文字
+</p>
+
+<p class="hidden text-red-600 font-bold" data-situation-form-target="error"></p>

--- a/app/views/situations/_form_text_area.html.erb
+++ b/app/views/situations/_form_text_area.html.erb
@@ -1,11 +1,13 @@
-<%= f.label attribute, 
-  class:"block text-gray-500 font-bold md:text-left mt-3 text-xl" 
+<%= f.label attribute,
+  class: "mt-3 block text-xl font-bold text-gray-500 md:text-left" 
 %>
 
-<%= f.text_area attribute, 
-  class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full h-50 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-orange-400", 
-  data: { situation_form_target: "input", 
-  action: "input->situation-form#clearError input->situation-form#count" }
+<%= f.text_area attribute,
+  class: "h-50 w-full appearance-none rounded border-2 border-gray-200 bg-gray-200 leading-tight text-gray-700 focus:border-orange-400 focus:bg-white focus:outline-none",
+  data: {
+    situation_form_target: "input",
+    action: "input->situation-form#clearError input->situation-form#count"
+  } 
 %>
 
 <p>

--- a/app/views/situations/_situation_attribute.html.erb
+++ b/app/views/situations/_situation_attribute.html.erb
@@ -1,0 +1,6 @@
+<div class="mt-3 mb-2">
+  <p class="text-xl font-bold text-gray-500">
+    <%= Situation.human_attribute_name(attribute) %>
+  </p>
+  <p><%= situation.public_send(attribute) %></p>
+</div>

--- a/app/views/situations/new.html.erb
+++ b/app/views/situations/new.html.erb
@@ -5,41 +5,20 @@
   <div>
     <%= form_with model: @situation, data: { action: "submit->situation-form#submit" } do |f| %>
       <div data-situation-form-target="step" class="block">
-        <%= f.label :fact, class:"block text-gray-500 font-bold md:text-left mt-3 text-xl" %>
-        <%= f.text_area :fact, class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full h-50 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-orange-400", data: { situation_form_target: "input", action: "input->situation-form#clearError input->situation-form#count" } %>
-
-        <p>
-          文字数： <span data-situation-form-target="output">0</span> / 300文字
-        </p>
-
-        <p class="hidden text-red-600 font-bold" data-situation-form-target="error"></p>
+        <%= render "form_text_area", f: f, attribute: :fact %>
 
         <button type="button" data-action="click->situation-form#next" class="bg-sky-700 hover:bg-sky-900 text-white font-bold mt-3 py-2 px-4 rounded">次へ</button>
       </div>
 
       <div data-situation-form-target="step" class="block">
-        <%= f.label :problem, class:"block text-gray-500 font-bold md:text-left mt-3 text-xl" %>
-        <%= f.text_area :problem, class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full h-50 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-orange-400", data: { situation_form_target: "input", action: "input->situation-form#clearError input->situation-form#count" } %>
-
-        <p>
-          文字数： <span data-situation-form-target="output">0</span> / 300文字
-        </p>
-
-        <p class="hidden text-red-600 font-bold" data-situation-form-target="error"></p>
+        <%= render "form_text_area", f: f, attribute: :problem %>
 
         <button type="button" data-action="click->situation-form#prev" class="bg-sky-700 hover:bg-sky-900 text-white font-bold mt-3 py-2 px-4 rounded">戻る</button>
         <button type="button" data-action="click->situation-form#next" class="bg-sky-700 hover:bg-sky-900 text-white font-bold mt-3 py-2 px-4 rounded">次へ</button>
       </div>
 
       <div data-situation-form-target="step" class="block">
-        <%= f.label :goal, class:"block text-gray-500 font-bold md:text-left mt-3 text-xl" %>
-        <%= f.text_area :goal, class: "bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full h-50 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-orange-400", data: { situation_form_target: "input", action: "input->situation-form#clearError input->situation-form#count" } %>
-
-        <p>
-          文字数： <span data-situation-form-target="output">0</span> / 300文字
-        </p>
-
-        <p class="hidden text-red-600 font-bold" data-situation-form-target="error"></p>
+        <%= render "form_text_area", f: f, attribute: :goal %>
 
         <button type="button" data-action="click->situation-form#prev" class="bg-sky-700 hover:bg-sky-900 text-white font-bold mt-3 py-2 px-4 rounded">戻る</button>
         <%= f.submit "送信", class:"bg-sky-700 hover:bg-sky-900 text-white font-bold mt-3 py-2 px-4 rounded" %>

--- a/app/views/situations/show.html.erb
+++ b/app/views/situations/show.html.erb
@@ -3,25 +3,8 @@
   <p>Find me in app/views/situations/show.html.erb</p>
 
   <div>
-    <div class="mt-3 mb-2">
-      <p class="text-xl font-bold text-gray-500">
-        <%= Situation.human_attribute_name(:fact) %>
-      </p>
-      <p><%= @situation.fact %></p>
-    </div>
-
-    <div class="mt-3 mb-2">
-      <p class="text-xl font-bold text-gray-500">
-        <%= Situation.human_attribute_name(:problem) %>
-      </p>
-      <p><%= @situation.problem %></p>
-    </div>
-
-    <div class="mt-3 mb-2">
-      <p class="text-xl font-bold text-gray-500">
-        <%= Situation.human_attribute_name(:goal) %>
-      </p>
-      <p><%= @situation.goal %></p>
-    </div>
+    <%= render "situation", situation: @situation, attribute: :fact %>
+    <%= render "situation", situation: @situation, attribute: :problem %>
+    <%= render "situation", situation: @situation, attribute: :goal %>
   </div>
 </div>

--- a/app/views/situations/show.html.erb
+++ b/app/views/situations/show.html.erb
@@ -1,10 +1,7 @@
-<div>
-  <h1 class="font-bold text-4xl">Situations#show</h1>
-  <p>Find me in app/views/situations/show.html.erb</p>
+<div class="mt-3 mb-2">
+  <p class="text-xl font-bold text-gray-500">
+    <%= Situation.human_attribute_name(attribute) %>
+  </p>
 
-  <div>
-    <%= render "situation", situation: @situation, attribute: :fact %>
-    <%= render "situation", situation: @situation, attribute: :problem %>
-    <%= render "situation", situation: @situation, attribute: :goal %>
-  </div>
+  <p><%= situation.public_send(attribute) %></p>
 </div>


### PR DESCRIPTION
## Issue

- #72
- #87

## 概要

入力画面と詳細画面は以下のように繰り返し使うため、パーシャル化する。

<img width="714" height="494" alt="image" src="https://github.com/user-attachments/assets/68e72b9c-500a-485b-bfc5-ec7e6c354a02" />

<img width="719" height="667" alt="image" src="https://github.com/user-attachments/assets/e9536994-255c-44c2-bf55-c78008a6edf5" />

Tailwind CSSのクラスが長くなってしまっているため、整理する。

- [x] 入力フォームをパーシャル化
- [x] 詳細画面をパーシャル化
- [x] クラスの並び順整理
- [x] `gem "htmlbeautifier"`の追加

## 日報

- [404日目：自作サービス11\(AIどれにするか決めた、文字数制限のテスト\) \| FBC](https://bootcamp.fjord.jp/reports/125046)

