### PR TITLE
ふりかえり詳細画面がパーシャルと同じファイルになっていた不具合を修正

### DIFF
--- a/app/views/situations/show.html.erb
+++ b/app/views/situations/show.html.erb
@@ -1,7 +1,10 @@
-<div class="mt-3 mb-2">
-  <p class="text-xl font-bold text-gray-500">
-    <%= Situation.human_attribute_name(attribute) %>
-  </p>
+<div>
+  <h1 class="font-bold text-4xl">Situations#show</h1>
+  <p>Find me in app/views/situations/show.html.erb</p>
 
-  <p><%= situation.public_send(attribute) %></p>
+  <div>
+    <%= render "situation_attribute", situation: @situation, attribute: :fact %>
+    <%= render "situation_attribute", situation: @situation, attribute: :problem %>
+    <%= render "situation_attribute", situation: @situation, attribute: :goal %>
+  </div>
 </div>


### PR DESCRIPTION
## Issue

- #72
- #89

## 概要

ふりかえり詳細画面がパーシャルと同じファイルになっていたミスを修正