### PR TITLE
ふりかえり履歴一覧画面を作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ gem "omniauth"
 gem "omniauth-google-oauth2"
 gem "omniauth-rails_csrf_protection"
 
+gem "kaminari"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,18 @@ GEM
       sshkit (>= 1.23.0, < 2.0)
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -455,6 +467,7 @@ DEPENDENCIES
   htmlbeautifier
   importmap-rails
   kamal
+  kaminari
   omniauth
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
@@ -527,6 +540,10 @@ CHECKSUMS
   json (2.19.8) sha256=6354310fd76ef69b87d5bd1f38b40d730613baf90b6803d2d0a48f618d32dfaa
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   kamal (2.11.0) sha256=1408864425e0dec7e0a14d712a3b13f614e9f3a425b7661d3f9d287a51d7dd75
+  kaminari (1.2.2) sha256=c4076ff9adccc6109408333f87b5c4abbda5e39dc464bd4c66d06d9f73442a3e
+  kaminari-actionview (1.2.2) sha256=1330f6fc8b59a4a4ef6a549ff8a224797289ebf7a3a503e8c1652535287cc909
+  kaminari-activerecord (1.2.2) sha256=0dd3a67bab356a356f36b3b7236bcb81cef313095365befe8e98057dd2472430
+  kaminari-core (1.2.2) sha256=3bd26fec7370645af40ca73b9426a448d09b8a8ba7afa9ba3c3e0d39cdbb83ff
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203

--- a/app/controllers/situations_controller.rb
+++ b/app/controllers/situations_controller.rb
@@ -2,7 +2,7 @@ class SituationsController < ApplicationController
   before_action :set_user, only: %i[index show new create]
 
   def index
-    @situations = current_user.situations
+    @situations = current_user.situations.order(created_at: :desc).page(params[:page])
   end
 
   def show

--- a/app/controllers/situations_controller.rb
+++ b/app/controllers/situations_controller.rb
@@ -2,6 +2,7 @@ class SituationsController < ApplicationController
   before_action :set_user, only: %i[index show new create]
 
   def index
+    @situations = current_user.situations
   end
 
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :situations, dependent: :destroy
+
   def self.find_or_create_from_auth_hash(auth)
     find_or_create_by!(
       provider: auth.provider,

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="first">
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="last">
+  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next">
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote %>
+</span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,12 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page<%= ' current' if page.current? %>">
+  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel} %>
+</span>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,25 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<%= paginator.render do -%>
+  <nav class="pagination mt-8 text-center text-2xl text-gray-500" role="navigation" aria-label="pager">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.display_tag? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <% unless current_page.out_of_range? %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    <% end %>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev">
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote %>
+</span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,7 @@
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
+    <script src="https://kit.fontawesome.com/54c0760265.js" crossorigin="anonymous"></script>
 
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>

--- a/app/views/situations/index.html.erb
+++ b/app/views/situations/index.html.erb
@@ -2,14 +2,16 @@
   <h1 class="font-bold text-4xl">Situations#index</h1>
   <p>Find me in app/views/situations/index.html.erb</p>
 
-  <ol style="list-style-type: decimal;">
-    <% @situations.each do |situation| %>
-      <li class="pt-3">
-        <%= 
-          link_to situation.fact, situation_path(situation.id), 
-          class: "text-orange-400 hover:text-orange-200"
-        %>
-      </li>
+  <% @situations.each do |situation| %>
+    <%= link_to situation_path(situation.id) do %>
+      <div class="m-5 p-4 border-2 border-gray-200 hover:-translate-y-1 hover:scale-105 hover:opacity-60">
+        <p class="text-gray-500">
+          <%= situation.created_at.strftime('%Y年%m月%d日 %H時%M分') %>
+        </p>
+        <p class="text-xl text-orange-400">
+          <%= situation.fact %>
+        </p>
+      </div>
     <% end %>
-  </ol>
+  <% end %>
 </div>

--- a/app/views/situations/index.html.erb
+++ b/app/views/situations/index.html.erb
@@ -2,10 +2,13 @@
   <h1 class="font-bold text-4xl">Situations#index</h1>
   <p>Find me in app/views/situations/index.html.erb</p>
 
-  <ol class="list-style-type: decimal;">
+  <ol style="list-style-type: decimal;">
     <% @situations.each do |situation| %>
-      <li>
-        <%= link_to situation.fact, situation_path(situation.id) %>
+      <li class="pt-3">
+        <%= 
+          link_to situation.fact, situation_path(situation.id), 
+          class: "text-orange-400 hover:text-orange-200"
+        %>
       </li>
     <% end %>
   </ol>

--- a/app/views/situations/index.html.erb
+++ b/app/views/situations/index.html.erb
@@ -4,7 +4,7 @@
 
   <% @situations.each do |situation| %>
     <%= link_to situation_path(situation.id) do %>
-      <div class="m-5 p-4 border-2 border-gray-200 hover:-translate-y-1 hover:scale-105 hover:opacity-60">
+      <div class="m-5 p-4 relative border-2 border-gray-200 hover:-translate-y-1 hover:scale-105 hover:opacity-60">
         <p class="text-gray-500">
           <%= situation.created_at.strftime('%Y年%m月%d日 %H時%M分') %>
         </p>
@@ -14,4 +14,6 @@
       </div>
     <% end %>
   <% end %>
+
+  <%= paginate @situations %>
 </div>

--- a/app/views/situations/index.html.erb
+++ b/app/views/situations/index.html.erb
@@ -1,4 +1,12 @@
 <div>
   <h1 class="font-bold text-4xl">Situations#index</h1>
   <p>Find me in app/views/situations/index.html.erb</p>
+
+  <ol class="list-style-type: decimal;">
+    <% @situations.each do |situation| %>
+      <li>
+        <%= link_to situation.fact, situation_path(situation.id) %>
+      </li>
+    <% end %>
+  </ol>
 </div>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 5
+  # config.max_per_page = nil
+  config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -3,7 +3,7 @@
 Kaminari.configure do |config|
   config.default_per_page = 5
   # config.max_per_page = nil
-  config.window = 4
+  # config.window = 4
   # config.outer_window = 0
   # config.left = 0
   # config.right = 0

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,3 +18,4 @@ ja:
       last: <i class="fas fa-angle-double-right"></i>
       previous: <i class="fas fa-angle-left"></i>
       next: <i class="fas fa-angle-right"></i>
+      truncate: "..."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,3 +12,9 @@ ja:
     create:
       created: "質問に解答しました。"
       alet: "質問の解答に失敗しました。"
+  views:
+    pagination:
+      first: <i class="fas fa-angle-double-left"></i>
+      last: <i class="fas fa-angle-double-right"></i>
+      previous: <i class="fas fa-angle-left"></i>
+      next: <i class="fas fa-angle-right"></i>


### PR DESCRIPTION
## Issue

- #41 
- #97

## 概要

- [x] 日付を表示させる
- [x] フレームなどで囲み、一覧を見やすくする
- [x] kaminariでページネーションを作成する

## 日報

- [404日目：自作サービス11\(AIどれにするか決めた、文字数制限のテスト\) \| FBC](https://bootcamp.fjord.jp/reports/125046)
- [406日目：チーム開発32\(\#10022、レビュー\#10208\)、自作サービス13\(履歴一覧作成\) \| FBC](https://bootcamp.fjord.jp/reports/125102)

## 要修正

- 詳細画面「入力内容の確認」はタスクを作る前の確認画面に移動させる必要がある