### PR TITLE
ふりかえり入力画面と詳細画面に例と説明文を追加

### DIFF
--- a/app/views/situations/_form_text_area.html.erb
+++ b/app/views/situations/_form_text_area.html.erb
@@ -1,7 +1,3 @@
-<%= f.label attribute,
-  class: "mt-3 block text-xl font-bold text-gray-500 md:text-left" 
-%>
-
 <%= f.text_area attribute,
   class: "h-50 w-full appearance-none rounded border-2 border-gray-200 bg-gray-200 leading-tight text-gray-700 focus:border-orange-400 focus:bg-white focus:outline-none",
   data: {

--- a/app/views/situations/_situation_attribute.html.erb
+++ b/app/views/situations/_situation_attribute.html.erb
@@ -1,6 +1,6 @@
-<div class="mt-3 mb-2">
-  <p class="text-xl font-bold text-gray-500">
+<div class="mt-5 mb-2">
+  <p class="pb-2 text-xl font-bold text-gray-500">
     <%= Situation.human_attribute_name(attribute) %>
   </p>
-  <p><%= situation.public_send(attribute) %></p>
+  <div class="p-2 border-2 border-gray-200"><%= situation.public_send(attribute) %></div>
 </div>

--- a/app/views/situations/new.html.erb
+++ b/app/views/situations/new.html.erb
@@ -1,28 +1,62 @@
 <div data-controller="situation-form">
-  <h1 class="font-bold text-4xl">Situations#new</h1>
-  <p>Find me in app/views/situations/new.html.erb</p>
-
-  <div>
-    <%= form_with model: @situation, data: { action: "submit->situation-form#submit" } do |f| %>
-      <div data-situation-form-target="step" class="block">
-        <%= render "form_text_area", f: f, attribute: :fact %>
-
-        <button type="button" data-action="click->situation-form#next" class="bg-sky-700 hover:bg-sky-900 text-white font-bold mt-3 py-2 px-4 rounded">次へ</button>
+  <%= form_with model: @situation, data: { action: "submit->situation-form#submit" } do |f| %>
+    <div data-situation-form-target="step" class="block">
+      <p class="text-3xl font-bold text-gray-600">
+        今どんなことが起きていますか？
+      </p>
+      <div class="mt-3 text-gray-500">
+        <p>
+          現在の状況や起きた出来事を具体的に書き出してみましょう。
+        </p>
+        <p class="mt-3 font-bold">例</p>
+        <ul class="list-disc mb-3 pl-8">
+          <li>「ビジネスメールが書けていない」と上司に指摘された</li>
+          <li>勉強したのにずっとSNSを見てしまう</li>
+          <li>やりたいことがあるのに疲れて何も始められない</li>
+        </ul>
       </div>
+      <%= render "form_text_area", f: f, attribute: :fact %>
+      <button type="button" data-action="click->situation-form#next" class="bg-sky-700 hover:bg-sky-900 text-white font-bold mt-3 py-2 px-4 rounded">次へ</button>
+    </div>
 
-      <div data-situation-form-target="step" class="block">
-        <%= render "form_text_area", f: f, attribute: :problem %>
-
-        <button type="button" data-action="click->situation-form#prev" class="bg-sky-700 hover:bg-sky-900 text-white font-bold mt-3 py-2 px-4 rounded">戻る</button>
-        <button type="button" data-action="click->situation-form#next" class="bg-sky-700 hover:bg-sky-900 text-white font-bold mt-3 py-2 px-4 rounded">次へ</button>
+    <div data-situation-form-target="step" class="block">
+      <p class="text-3xl font-bold text-gray-600">
+        今一番困っていることは何ですか？
+      </p>
+      <div class="mt-3 text-gray-500">
+        <p>
+          一番モヤモヤしたことや気になっていることを書き出してみましょう。
+        </p>
+        <p class="mt-3 font-bold">例</p>
+        <ul class="list-disc mb-3 pl-8">
+          <li>メールのどこが悪いのか分からず修正できない</li>
+          <li>周りが気になって自分の作業に集中できない</li>
+          <li>情報を集めすぎて動けなくなっている</li>
+        </ul>
       </div>
+      <%= render "form_text_area", f: f, attribute: :problem %>
+      <button type="button" data-action="click->situation-form#prev" class="bg-sky-700 hover:bg-sky-900 text-white font-bold mt-3 py-2 px-4 rounded">戻る</button>
+      <button type="button" data-action="click->situation-form#next" class="bg-sky-700 hover:bg-sky-900 text-white font-bold mt-3 py-2 px-4 rounded">次へ</button>
+    </div>
 
-      <div data-situation-form-target="step" class="block">
-        <%= render "form_text_area", f: f, attribute: :goal %>
-
-        <button type="button" data-action="click->situation-form#prev" class="bg-sky-700 hover:bg-sky-900 text-white font-bold mt-3 py-2 px-4 rounded">戻る</button>
-        <%= f.submit "送信", class:"bg-sky-700 hover:bg-sky-900 text-white font-bold mt-3 py-2 px-4 rounded" %>
+    <div data-situation-form-target="step" class="block">
+      <p class="text-3xl font-bold text-gray-600">
+        どんな状態になれたら良さそうですか？
+      </p>
+      <div class="mt-3 text-gray-500">
+        <p>
+          自分自身が将来的にどのような状態になりたか、理想の状態を書き出してみましょう。
+        </p>
+        <p class="mt-3 font-bold">例</p>
+        <ul class="list-disc mb-3 pl-8">
+          <li>メールを修正して、次回は自分で書けるようになりたい</li>
+          <li>SNSを見る時間を減らして、少しでも作業を進めたい</li>
+          <li>自分の作業に集中できるようになりたい</li>
+        </ul>
       </div>
-    <% end %>
-  </div>
+      <%= render "form_text_area", f: f, attribute: :goal %>
+      <button type="button" data-action="click->situation-form#prev" class="bg-sky-700 hover:bg-sky-900 text-white font-bold mt-3 py-2 px-4 rounded">戻る</button>
+      <%= f.submit "送信", class:"bg-sky-700 hover:bg-sky-900 text-white font-bold mt-3 py-2 px-4 rounded" %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/situations/show.html.erb
+++ b/app/views/situations/show.html.erb
@@ -1,7 +1,13 @@
 <div>
-  <h1 class="font-bold text-4xl">Situations#show</h1>
-  <p>Find me in app/views/situations/show.html.erb</p>
-
+  <div>
+    <p class="text-3xl font-bold text-gray-600">
+      入力内容の確認
+    </p>
+    <p class="mt-3 text-gray-500">
+      以下の内容から、AIによってTodoリストを作成します。<br>
+      問題なければ「次へ」を押してください。
+    </p>
+  </div>
   <div>
     <%= render "situation_attribute", situation: @situation, attribute: :fact %>
     <%= render "situation_attribute", situation: @situation, attribute: :problem %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,8 +2,8 @@ ja:
   activerecord:
     attributes:
       situation:
-        fact: 現在の状況
-        problem: 悩み
+        fact: 現状
+        problem: 問題
         goal: 目標
   errors:
     messages:


### PR DESCRIPTION
## Issue

- #99 

## 概要

[ペーパープロトタイプ](https://bootcamp.fjord.jp/products/23756) に寄せて説明文を追加する。
ユーザーが振り返りを入力しやすいような例と説明を入れる。

また、説明とラベルの内容が被っていて冗長的なため、`app/views/situations/_form_text_area.html.erb`からラベルを削除しました。
編集画面などでラベルが必要な場合は、適宜追加する必要があります。
