### PR TITLE
通知を一定時間で消えるようにする

### DIFF
--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  connect() {
+    setTimeout(() => {
+      this.element.remove();
+    }, 2000);
+  }
+}

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -3,7 +3,10 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
   connect() {
     setTimeout(() => {
+      this.element.classList.add("opacity-0");
+    }, 100);
+    setTimeout(() => {
       this.element.remove();
-    }, 2000);
+    }, 4000);
   }
 }

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -3,10 +3,11 @@ import { Controller } from "@hotwired/stimulus";
 export default class extends Controller {
   connect() {
     setTimeout(() => {
-      this.element.classList.add("opacity-0");
-    }, 100);
-    setTimeout(() => {
       this.element.remove();
-    }, 4000);
+    }, 2000);
+  }
+
+  disconnect() {
+    if (this.dismissTimer) clearTimeout(this.dismissTimer);
   }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,13 +27,13 @@
   <body>
     <%= render "shared/header" unless current_page?(root_path) %>
     <% if notice.present? %>
-      <div class="absolute top-20 right-20 w-[300px] rounded border border-green-700 bg-green-200 px-4 py-3 text-green-700" role="notice">
+      <div data-controller="flash" class="absolute top-20 right-20 w-[300px] rounded border border-green-700 bg-green-200 px-4 py-3 text-green-700" role="notice">
         <%= notice %>
       </div>
     <% end %>
 
     <% if alert.present? %>
-      <div class="absolute top-20 right-20 w-[300px] rounded border border-red-700 bg-red-200 px-4 py-3 text-red-700" role="alert">
+      <div data-controller="flash" class="absolute top-20 right-20 w-[300px] rounded border border-red-700 bg-red-200 px-4 py-3 text-red-700" role="alert">
         <%= alert %>
       </div>
     <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,7 @@
   <body>
     <%= render "shared/header" unless current_page?(root_path) %>
     <% if notice.present? %>
-      <div data-controller="flash" class="absolute top-20 right-20 w-[300px] rounded border border-green-700 bg-green-200 px-4 py-3 text-green-700 transition-opacity duration-[3000ms] ease-linear" role="notice">
+      <div data-controller="flash" class="absolute top-20 right-20 w-[300px] rounded border border-green-700 bg-green-200 px-4 py-3 text-green-700 transition-opacity duration-[3000ms] ease-linear" role="status" aria-live="polite">
         <%= notice %>
       </div>
     <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,13 +27,13 @@
   <body>
     <%= render "shared/header" unless current_page?(root_path) %>
     <% if notice.present? %>
-      <div data-controller="flash" class="absolute top-20 right-20 w-[300px] rounded border border-green-700 bg-green-200 px-4 py-3 text-green-700" role="notice">
+      <div data-controller="flash" class="absolute top-20 right-20 w-[300px] rounded border border-green-700 bg-green-200 px-4 py-3 text-green-700 transition-opacity duration-[3000ms] ease-linear" role="notice">
         <%= notice %>
       </div>
     <% end %>
 
     <% if alert.present? %>
-      <div data-controller="flash" class="absolute top-20 right-20 w-[300px] rounded border border-red-700 bg-red-200 px-4 py-3 text-red-700" role="alert">
+      <div data-controller="flash" class="absolute top-20 right-20 w-[300px] rounded border border-red-700 bg-red-200 px-4 py-3 text-red-700 transition-opacity duration-[3000ms] ease-linear" role="alert">
         <%= alert %>
       </div>
     <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,7 +11,7 @@ ja:
   situations:
     create:
       created: "質問に回答しました。"
-      alet: "質問の回答に失敗しました。"
+      alert: "質問の回答に失敗しました。"
   views:
     pagination:
       first: <i class="fas fa-angle-double-left"></i>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,8 +10,8 @@ ja:
       blank: を入力してください
   situations:
     create:
-      created: "質問に解答しました。"
-      alet: "質問の解答に失敗しました。"
+      created: "質問に回答しました。"
+      alet: "質問の回答に失敗しました。"
   views:
     pagination:
       first: <i class="fas fa-angle-double-left"></i>

--- a/spec/requests/situations_spec.rb
+++ b/spec/requests/situations_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Situations", type: :request do
         post situations_path, params: params
       end.to change(Situation, :count).by(1)
       expect(response).to redirect_to situation_path(Situation.last)
-      expect(flash[:notice]).to eq('質問に解答しました。')
+      expect(flash[:notice]).to eq('質問に回答しました。')
     end
   end
 end


### PR DESCRIPTION
## Issue

- #106 

## 概要

## 日報

- [407日目：自作サービス14\(ハンバーガーメニューを追加、通知を時間経過で消す\) \| FBC](https://bootcamp.fjord.jp/reports/125129)

## スクリーンショット

### 変更前

### 変更後


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 通知・アラートのフラッシュメッセージが自動でフェードアウトし、一定時間後に表示を消すようになりました。
* **Bug Fixes**
  * フラッシュ通知領域の属性（role/aria-live）と表示・消去アニメーションが反映されました。
  * 日本語の文言（「質問に回答しました／回答に失敗しました」等）を正しい表現に修正しました。
* **Tests**
  * フラッシュ表示の期待値を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->