### PR TITLE
ふりかえり機能のシステムテストを追加

### DIFF
--- a/app/views/situations/new.html.erb
+++ b/app/views/situations/new.html.erb
@@ -16,7 +16,7 @@
         </ul>
       </div>
       <%= render "form_text_area", f: f, attribute: :fact %>
-      <button type="button" data-action="click->situation-form#next" class="bg-dusty-denim hover:opacity-60 text-white font-bold mt-3 py-2 px-4 rounded">次へ</button>
+      <button type="button" data-testid="fact-next-button" data-action="click->situation-form#next" class="bg-dusty-denim hover:opacity-60 text-white font-bold mt-3 py-2 px-4 rounded">次へ</button>
     </div>
 
     <div data-situation-form-target="step" class="block">
@@ -36,7 +36,7 @@
       </div>
       <%= render "form_text_area", f: f, attribute: :problem %>
       <button type="button" data-action="click->situation-form#prev" class="bg-dusty-denim hover:opacity-60 text-white font-bold mt-3 py-2 px-4 rounded">戻る</button>
-      <button type="button" data-action="click->situation-form#next" class="bg-dusty-denim hover:opacity-60 text-white font-bold mt-3 py-2 px-4 rounded">次へ</button>
+      <button type="button" data-testid="problem-next-button" data-action="click->situation-form#next" class="bg-dusty-denim hover:opacity-60 text-white font-bold mt-3 py-2 px-4 rounded">次へ</button>
     </div>
 
     <div data-situation-form-target="step" class="block">

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
     provider { "google_oauth2" }
-    uid { SecureRandom.uuid }
+    uid { "123456789" }
     email_address { "test@example.com" }
     name { "テスト太郎" }
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
     provider { "google_oauth2" }
-    uid { "123456789" }
+    uid { SecureRandom.uuid }
     email_address { "test@example.com" }
     name { "テスト太郎" }
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,8 @@ rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
 
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+
 RSpec.configure do |config|
   config.fixture_paths = [
     Rails.root.join('spec/fixtures')
@@ -24,14 +26,4 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 
   OmniAuth.config.test_mode = true
-
-  OmniAuth.config.mock_auth[:google_oauth2] =
-    OmniAuth::AuthHash.new(
-      provider: "google_oauth2",
-      uid: "123456789",
-      info: {
-        email_address: "test@example.com",
-        name: "テスト太郎"
-      }
-    )
 end

--- a/spec/requests/google_login_spec.rb
+++ b/spec/requests/google_login_spec.rb
@@ -23,7 +23,15 @@ RSpec.describe "Googleログイン", type: :request do
   end
 
   context "既存ユーザーがいる場合" do
-    let!(:user) { FactoryBot.create(:user) }
+    let!(:user) do
+      FactoryBot.create(
+        :user,
+        provider: "google_oauth2",
+        uid: "123456789",
+        email_address: "test@example.com",
+        name: "テスト太郎"
+      )
+    end
 
     it "新しく追加しない" do
       expect do

--- a/spec/requests/google_login_spec.rb
+++ b/spec/requests/google_login_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Googleログイン", type: :request do
+  it "ユーザーを作成し、ログインする" do
+    expect do
+      get "/auth/google_oauth2/callback"
+    end.to change(User, :count).by(1)
+
+    expect(session[:user_id]).to be_present
+  end
+
+  context "既存ユーザーがいる場合 " do
+    let!(:user) do
+      User.create!(
+        email_address: "test@example.com",
+        provider: "google_oauth2",
+        uid: "123456789"
+      )
+    end
+
+    it "新しく追加しない" do
+      expect do
+        get "/auth/google_oauth2/callback"
+      end.not_to change(User, :count)
+    end
+  end
+end

--- a/spec/requests/google_login_spec.rb
+++ b/spec/requests/google_login_spec.rb
@@ -1,6 +1,19 @@
 require "rails_helper"
 
 RSpec.describe "Googleログイン", type: :request do
+  before do
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:google_oauth2] =
+      OmniAuth::AuthHash.new(
+        provider: "google_oauth2",
+        uid: "123456789",
+        info: {
+          email: "test@example.com",
+          name: "テスト太郎"
+        }
+      )
+  end
+
   it "ユーザーを作成し、ログインする" do
     expect do
       get "/auth/google_oauth2/callback"
@@ -9,14 +22,8 @@ RSpec.describe "Googleログイン", type: :request do
     expect(session[:user_id]).to be_present
   end
 
-  context "既存ユーザーがいる場合 " do
-    let!(:user) do
-      User.create!(
-        email_address: "test@example.com",
-        provider: "google_oauth2",
-        uid: "123456789"
-      )
-    end
+  context "既存ユーザーがいる場合" do
+    let!(:user) { FactoryBot.create(:user) }
 
     it "新しく追加しない" do
       expect do

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -1,0 +1,19 @@
+module SystemHelpers
+  def sign_in_as(user)
+    OmniAuth.config.mock_auth[:google_oauth2] =
+      OmniAuth::AuthHash.new(
+        provider: user.provider,
+        uid: user.uid,
+        info: {
+          email: user.email_address,
+          name: user.name
+        }
+      )
+    visit root_path
+    click_button "Googleでログイン"
+  end
+end
+
+RSpec.configure do |config|
+  config.include SystemHelpers, type: :system
+end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -5,7 +5,7 @@ module SystemHelpers
         provider: user.provider,
         uid: user.uid,
         info: {
-          email: user.email_address,
+          email_address: user.email_address,
           name: user.name
         }
       )

--- a/spec/system/google_login_spec.rb
+++ b/spec/system/google_login_spec.rb
@@ -1,27 +1,15 @@
 require "rails_helper"
 
-RSpec.describe "Googleログイン", type: :request do
-  it "ユーザーを作成し、ログインする" do
-    expect do
-      get "/auth/google_oauth2/callback"
-    end.to change(User, :count).by(1)
-
-    expect(session[:user_id]).to be_present
+RSpec.describe "Googleログイン", type: :system do
+  before do
+    driven_by(:rack_test)
   end
 
-  context "既存ユーザーがいる場合 " do
-    let!(:user) do
-      User.create!(
-        email_address: "test@example.com",
-        provider: "google_oauth2",
-        uid: "123456789"
-      )
-    end
+  scenario "ログインすると、ふりかえりの入力画面に遷移する" do
+    visit root_path
 
-    it "新しく追加しない" do
-      expect do
-        get "/auth/google_oauth2/callback"
-      end.not_to change(User, :count)
-    end
+    click_button "Googleでログイン"
+
+    expect(page).to have_content "今どんなことが起きていますか？"
   end
 end

--- a/spec/system/situations_spec.rb
+++ b/spec/system/situations_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe "Situations", type: :system do
+  let(:user) { FactoryBot.create(:user) }
+
+  before do
+    driven_by(:selenium_chrome_headless)
+    sign_in_as(user)
+  end
+
+  scenario "ユーザーが振り返りを作成できる" do
+    visit new_situation_path
+
+    fill_in "situation_fact", with: "会議で進捗報告をしたが、うまく説明できなかった。"
+    find('[data-testid="fact-next-button"]').click
+
+    fill_in "situation_problem", with: "話す内容が整理できておらず、自信を持って説明できない。"
+    find('[data-testid="problem-next-button"]').click
+
+    fill_in "situation_goal", with: "次回の会議では要点を整理して説明できるようになりたい。"
+    click_button "送信"
+
+    expect(page).to have_content "会議で進捗報告をしたが、うまく説明できなかった。"
+    expect(page).to have_content "話す内容が整理できておらず、自信を持って説明できない。"
+    expect(page).to have_content "次回の会議では要点を整理して説明できるようになりたい。"
+  end
+
+  scenario "301文字以上は登録できない" do
+    visit new_situation_path
+    fill_in "situation_fact", with: "あ" * 301
+    find('[data-testid="fact-next-button"]').click
+
+    expect(page).to have_content "300文字以内にしてください。"
+  end
+
+  scenario "空欄では次に進めない" do
+    visit new_situation_path
+    fill_in "situation_fact", with: ""
+    find('[data-testid="fact-next-button"]').click
+
+    expect(page).to have_content "入力してください。"
+  end
+
+  scenario "作成したふりかえりが一覧画面に表示される" do
+    situation = FactoryBot.create(:situation, user: user)
+
+    visit situations_path
+    expect(page).to have_content situation.fact
+
+    click_link situation.fact
+    expect(page).to have_content situation.fact
+    expect(page).to have_content situation.problem
+    expect(page).to have_content situation.goal
+  end
+end


### PR DESCRIPTION
## Issue

- #75
- #51 

## 日報

- [410日目：自作サービス16\(システムテストを書く\) \| FBC](https://bootcamp.fjord.jp/reports/125230)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests
* **Google ログインのテスト強化**
  * 新規ユーザー作成時にログイン状態が正しく反映されることを検証するリクエストテストを追加
  * 画面上の「Googleでログイン」導線に沿ったシナリオベースのシステムテストへ整理
  * テスト補助のサインイン操作を追加し、テストデータ（UID）を安定化
* **ふりかえり作成フローのテスト追加**
  * 入力内容の表示、文字数（300文字以内）と必須エラー、既存データの表示と遷移を検証
<!-- end of auto-generated comment: release notes by coderabbit.ai -->